### PR TITLE
Deployment info in Redaxo verfügbar machen

### DIFF
--- a/deployer/tasks/deploy/dump_info.php
+++ b/deployer/tasks/deploy/dump_info.php
@@ -8,7 +8,7 @@ task('deploy:dump_info', function () {
         'host' => get('hostname'),
         'stage' => get('stage', false) ?: null,
         'timestamp' => time(),
-        'commit' => runLocally('git -C .build rev-parse HEAD'),
+        'commit' => runLocally('{{bin/git}} -C .build rev-parse HEAD'),
     ];
 
     $infos = json_encode($infos, JSON_PRETTY_PRINT);

--- a/deployer/tasks/deploy/dump_info.php
+++ b/deployer/tasks/deploy/dump_info.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Deployer;
+
+desc('Dump info about current deployment');
+task('deploy:dump_info', function () {
+    $infos = [
+        'host' => get('hostname'),
+        'stage' => get('stage', false) ?: null,
+        'timestamp' => time(),
+        'commit' => runLocally('git -C .build rev-parse HEAD'),
+    ];
+
+    $infos = json_encode($infos, JSON_PRETTY_PRINT);
+
+    run('mkdir -p {{release_path}}/{{data_dir}}/addons/ydeploy');
+    run('echo '.escapeshellarg($infos).' > {{release_path}}/{{data_dir}}/addons/ydeploy/info.json');
+});

--- a/deployer/tasks/deploy/dump_info.php
+++ b/deployer/tasks/deploy/dump_info.php
@@ -8,6 +8,7 @@ task('deploy:dump_info', function () {
         'host' => get('hostname'),
         'stage' => get('stage', false) ?: null,
         'timestamp' => time(),
+        'branch' => runLocally('{{bin/git}} -C .build rev-parse --abbrev-ref HEAD'),
         'commit' => runLocally('{{bin/git}} -C .build rev-parse HEAD'),
     ];
 

--- a/deployer/tasks/release.php
+++ b/deployer/tasks/release.php
@@ -10,6 +10,7 @@ task('release', [
     'deploy:copy_dirs',
     'upload',
     'deploy:shared',
+    'deploy:dump_info',
     'deploy:writable',
     'database:migration',
     'deploy:symlink',

--- a/lib/ydeploy.php
+++ b/lib/ydeploy.php
@@ -1,0 +1,92 @@
+<?php
+
+class rex_ydeploy
+{
+    private static $instance;
+
+    private $deployed;
+
+    private $host;
+    private $stage;
+    private $commit;
+    private $timestamp;
+
+    private function __construct()
+    {
+        $path = rex_path::addonData('ydeploy', 'info.json');
+
+        if (!file_exists($path)) {
+            $this->deployed = false;
+
+            return;
+        }
+
+        $this->deployed = true;
+
+        $info = rex_file::getCache($path);
+
+        $this->host = $info['host'];
+        $this->stage = $info['stage'];
+        $this->commit = $info['commit'];
+        $this->timestamp = DateTimeImmutable::createFromFormat('U', $info['timestamp']);
+    }
+
+    public static function factory(): self
+    {
+        if (self::$instance) {
+            return self::$instance;
+        }
+
+        return self::$instance = new self();
+    }
+
+    /**
+     * Returns whether this a deployed or local instance.
+     *
+     * @return bool
+     */
+    public function isDeployed(): bool
+    {
+        return $this->deployed;
+    }
+
+    /**
+     * Returns the host name (from deploy.php).
+     *
+     * @return null|string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Returns the stage name (from deploy.php).
+     *
+     * @return null|string
+     */
+    public function getStage()
+    {
+        return $this->stage;
+    }
+
+    /**
+     * Returns the hash of the deployed commit.
+     *
+     * @return null|string
+     */
+    public function getCommit()
+    {
+        return $this->commit;
+    }
+
+    /**
+     * Returns timestamp of last deployment.
+     *
+     * @return null|DateTimeImmutable
+     */
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+}

--- a/lib/ydeploy.php
+++ b/lib/ydeploy.php
@@ -8,6 +8,7 @@ class rex_ydeploy
 
     private $host;
     private $stage;
+    private $branch;
     private $commit;
     private $timestamp;
 
@@ -27,6 +28,7 @@ class rex_ydeploy
 
         $this->host = $info['host'];
         $this->stage = $info['stage'];
+        $this->branch = $info['branch'];
         $this->commit = $info['commit'];
         $this->timestamp = DateTimeImmutable::createFromFormat('U', $info['timestamp']);
     }
@@ -68,6 +70,16 @@ class rex_ydeploy
     public function getStage()
     {
         return $this->stage;
+    }
+
+    /**
+     * Returns the deployed branch.
+     *
+     * @return null|string
+     */
+    public function getBranch()
+    {
+        return $this->branch;
     }
 
     /**

--- a/lib/ydeploy.php
+++ b/lib/ydeploy.php
@@ -41,7 +41,7 @@ class rex_ydeploy
     }
 
     /**
-     * Returns whether this a deployed or local instance.
+     * Returns whether this a deployed (`true`) or local (`false`) instance.
      *
      * @return bool
      */

--- a/package.yml
+++ b/package.yml
@@ -33,3 +33,7 @@ config:
 console_commands:
     ydeploy:diff: rex_ydeploy_command_diff
     ydeploy:migrate: rex_ydeploy_command_migrate
+
+pages:
+    system/ydeploy:
+        title: YDeploy

--- a/pages/system.ydeploy.php
+++ b/pages/system.ydeploy.php
@@ -1,0 +1,30 @@
+<?php
+
+$ydeploy = rex_ydeploy::factory();
+
+if ($ydeploy->isDeployed()) {
+    $info = [
+        'Deployed' => rex_formatter::strftime($ydeploy->getTimestamp()->getTimestamp(), 'datetime'),
+        'Host' => $ydeploy->getHost(),
+        'Stage' => $ydeploy->getStage(),
+        'Commit' => $ydeploy->getCommit(),
+    ];
+} else {
+    $info = [
+        'Deployed' => rex_i18n::rawMsg('no'),
+    ];
+}
+
+$content = '';
+
+foreach ($info as $key => $value) {
+    $content .= '<dt>'.rex_escape($key).'</dt>';
+    $content .= '<dd>'.rex_escape($value).'</dd>';
+}
+
+$content = '<dl class="dl-horizontal">'.$content.'</dl>';
+
+$fragment = new rex_fragment();
+$fragment->setVar('title', 'Info');
+$fragment->setVar('body', $content, false);
+echo $fragment->parse('core/page/section.php');

--- a/pages/system.ydeploy.php
+++ b/pages/system.ydeploy.php
@@ -7,6 +7,7 @@ if ($ydeploy->isDeployed()) {
         'Deployed' => rex_formatter::strftime($ydeploy->getTimestamp()->getTimestamp(), 'datetime'),
         'Host' => $ydeploy->getHost(),
         'Stage' => $ydeploy->getStage(),
+        'Branch' => $ydeploy->getBranch(),
         'Commit' => $ydeploy->getCommit(),
     ];
 } else {


### PR DESCRIPTION
Durch diesen PR kann man in REDAXO abfragen, ob die Instanz deployed ist oder nicht + Host, Stage, Commit und Timestamp.

```php
$ydeploy = rex_ydeploy::factory();
$ydeploy->isDeployed();
$ydeploy->getHost();
$ydeploy->getStage();
$ydeploy->getCommit();
$ydeploy->getTimestamp();
```

@tbaddade Gibt es noch weitere Infos, die du sinnvoll fändest?