### PR TITLE
YDeploy-Badge und Body-Classes

### DIFF
--- a/assets/ydeploy.css
+++ b/assets/ydeploy.css
@@ -1,0 +1,36 @@
+.ydeploy-badge {
+    position: fixed;
+    top: 0;
+    left: 50%;
+    z-index: 10000;
+    transform: translate(-50%, 0);
+    padding: 5px 20px;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    box-shadow: 0 0 5px 0 rgba(0,0,0, .4);
+    background-color: #ccc;
+    color: #000;
+    font-size: 13px;
+    font-family: 'Fira Code', 'Menlo', monospace;
+    font-weight: 400;
+}
+
+.ydeploy-badge small {
+    font-size: 100%;
+}
+
+.ydeploy-is-not-deployed .ydeploy-badge {
+    background-color: #0f6;
+}
+
+.ydeploy-stage-staging .ydeploy-badge,
+.ydeploy-stage-test .ydeploy-badge,
+.ydeploy-stage-testing .ydeploy-badge {
+    background-color: #fc0;
+}
+
+.ydeploy-stage-live .ydeploy-badge,
+.ydeploy-stage-prod .ydeploy-badge,
+.ydeploy-stage-production .ydeploy-badge {
+    background-color: #f66;
+}

--- a/boot.php
+++ b/boot.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var rex_addon $this */
+
+if (!rex::isBackend() || !rex::getUser()) {
+    return;
+}
+
+rex_view::addCssFile($this->getAssetsUrl('ydeploy.css'));
+
+rex_extension::register('PAGE_BODY_ATTR', 'rex_ydeploy_handler::addBodyClasses');
+rex_extension::register('OUTPUT_FILTER', 'rex_ydeploy_handler::addBadge');

--- a/lib/handler.php
+++ b/lib/handler.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @internal
+ */
+class rex_ydeploy_handler
+{
+    public static function addBodyClasses(rex_extension_point $ep)
+    {
+        $ydeploy = rex_ydeploy::factory();
+
+        $attr = $ep->getSubject();
+
+        if ($ydeploy->isDeployed()) {
+            $attr['class'][] = 'ydeploy-is-deployed';
+
+            if ($ydeploy->getStage()) {
+                $attr['class'][] = 'ydeploy-stage-'.rex_string::normalize($ydeploy->getStage(), '-');
+            }
+        } else {
+            $attr['class'][] = 'ydeploy-is-not-deployed';
+        }
+
+        return $attr;
+    }
+
+    public static function addBadge(rex_extension_point $ep)
+    {
+        $ydeploy = rex_ydeploy::factory();
+
+        if ($ydeploy->isDeployed()) {
+            $badge = $ydeploy->getHost();
+
+            if ($ydeploy->getStage()) {
+                $badge .= ' – '.ucfirst($ydeploy->getStage());
+            }
+        } else {
+            $badge = 'Development';
+        }
+
+        $badge = rex_extension::registerPoint(new rex_extension_point('YDEPLOY_BADGE', $badge));
+
+        if (!$badge) {
+            return;
+        }
+
+        $badge = '<div class="ydeploy-badge">'.$badge.'</div>';
+
+        return str_replace('</body>', $badge.'</body>', $ep->getSubject());
+    }
+}


### PR DESCRIPTION
Der PR fügt zum Einen allgemein Klassen an das `<body>`-Element an:
`ydeploy-is-deployed` bzw. `ydeploy-is-not-deployed`
Plus ggf. `ydeploy-stage-<stagename>`

Und zum Anderen fügt es dieses Badge ein, so wie wir es bisher über Yakme machen.
Dabei war ich mir aber unsicher, was es nun genau enthalten soll. Aktuell enthält es Host + ggf. Stage, bzw. "Development".
Man kann den Inhalt aber über den EP `YDEPLOY_BADGE` erweitern/ersetzen.
(@tbaddade nutzt zum Beispiel aktuell immer eine Art Versionsnummer, die dort mit ausgegeben wird. Finde ich aber schwierig, hier allgemein zu integrieren, bzw. möchte die Nutzer nicht dazu zwingen, eine Versionsnummer für ihre Websites einführen zu müssen.)

Aktuell habe ich nun drei Farben, grün für lokal, gelb für die Stages "staging", "test" bzw. "testing" und rot für "live", "prod" bzw. "production".
Dachte mir, so kann man es bisschen offen lassen, was man für ein Namensschema für die Stages nutzen möchte, und trotzdem bekommt man die richtigen Farben.

![screenshot 2018-03-18 23 17 44](https://user-images.githubusercontent.com/330436/37571898-505e5cf0-2b03-11e8-8472-3bacb0eb08e2.png)

![screenshot 2018-03-18 23 16 33](https://user-images.githubusercontent.com/330436/37571901-52bc3206-2b03-11e8-91dc-cf04480823b0.png)

![screenshot 2018-03-18 23 17 14](https://user-images.githubusercontent.com/330436/37571903-5464e7ba-2b03-11e8-93b0-a7f87c2dea74.png)