### PR TITLE
ignore VIEWs, change deprecated `showTables()` to `getTables()`

### DIFF
--- a/lib/command/diff.php
+++ b/lib/command/diff.php
@@ -25,8 +25,7 @@ final class rex_ydeploy_command_diff extends rex_ydeploy_command_abstract
 
         $io->title('YDeploy diff');
 
-        $sql = rex_sql::factory();
-        $tables = $sql->getTables(rex::getTablePrefix());
+        $tables = rex_sql::factory()->getTables(rex::getTablePrefix());
 
         /** @var rex_sql_table[] $tables */
         $tables = array_map('rex_sql_table::get', $tables);

--- a/lib/command/diff.php
+++ b/lib/command/diff.php
@@ -25,7 +25,8 @@ final class rex_ydeploy_command_diff extends rex_ydeploy_command_abstract
 
         $io->title('YDeploy diff');
 
-        $tables = rex_sql::showTables(1, rex::getTablePrefix());
+        $sql = rex_sql::factory();
+        $tables = $sql->getTables(1, rex::getTablePrefix());
 
         /** @var rex_sql_table[] $tables */
         $tables = array_map('rex_sql_table::get', $tables);

--- a/lib/command/diff.php
+++ b/lib/command/diff.php
@@ -26,7 +26,7 @@ final class rex_ydeploy_command_diff extends rex_ydeploy_command_abstract
         $io->title('YDeploy diff');
 
         $sql = rex_sql::factory();
-        $tables = $sql->getTables(1, rex::getTablePrefix());
+        $tables = $sql->getTables(rex::getTablePrefix());
 
         /** @var rex_sql_table[] $tables */
         $tables = array_map('rex_sql_table::get', $tables);


### PR DESCRIPTION
Wenn im Projekt ein oder mehrere VIEWs sind, haben diese nicht in Zeile 144 in der `diff.php` kein Charset und dadurch wird ein Fehler erzeugt:

```
In diff.php line 144:

  Undefined index: rex_NAME_DER_VIEW  
```