### PR TITLE
Installer wieder als Ganzes schützen

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -40,9 +40,7 @@ config:
             yform_field: ~
             yform_table: ~
     protected_pages:
-        install:
-            packages:
-                - add
+        install: ~
         markitup: ~
         media_manager: ~
         metainfo: ~


### PR DESCRIPTION
Habe in #53 versehentlich eine Änderung bzgl. des Installer-Schutzes gemerged, die eigentlich nur ein lokaler Test war.