### PR TITLE
Build-Command: Info ohne Release-Nummer

### DIFF
--- a/deployer/tasks/build.php
+++ b/deployer/tasks/build.php
@@ -4,7 +4,7 @@ namespace Deployer;
 
 desc('Prepare the next release locally');
 task('build', [
-    'deploy:info',
+    'build:info',
     'build:setup',
     'build:vendors',
     'build:assets',

--- a/deployer/tasks/build/info.php
+++ b/deployer/tasks/build/info.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Deployer;
+
+desc('Displays info about build');
+task('build:info', function () {
+    info('building <fg=magenta;options=bold>{{target}}</>');
+});


### PR DESCRIPTION
Beim Build-Command macht die Release-Nummer in der Info-Message keinen Sinn, daher ein eigener `build:info`-Command