### PR TITLE
Migrate-Command: Errors nicht unterdrücken

### DIFF
--- a/lib/command/migrate.php
+++ b/lib/command/migrate.php
@@ -82,9 +82,9 @@ final class rex_ydeploy_command_migrate extends rex_ydeploy_command_abstract
             }
 
             $io->error(sprintf('%s %d of %d migrations, aborted with "%s".', $fake ? 'Faked' : 'Executed', $countMigrated, count($paths), basename($path)));
-
-            return Command::FAILURE;
         }
+
+        return Command::FAILURE;
     }
 
     private function migrate($path): void


### PR DESCRIPTION
Aktuell wurden die Errors unterdrückt, was die Fehleranalyse sehr schwer machte bei fehlerhaften Migrationsdateien.