### PR TITLE
git-cli nicht auf Remote-Server suchen

### DIFF
--- a/deployer/config.php
+++ b/deployer/config.php
@@ -47,7 +47,14 @@ if (in_array($command, ['build', 'setup', 'worker'], true)) {
     host('local');
 }
 
-set('branch', static fn () => runLocally('{{bin/git}} rev-parse --abbrev-ref HEAD'));
+set('branch', static function () {
+    $branch = null;
+    on(host('local'), static function () use (&$branch) {
+        $branch = run('{{bin/git}} rev-parse --abbrev-ref HEAD');
+    });
+
+    return $branch;
+});
 
 $baseDir = $rootPath;
 if (str_starts_with($baseDir, getcwd())) {


### PR DESCRIPTION
fixes #89

Ich denke, dass es so am "saubersten" gelöst ist.