### PR TITLE
schema.yml: Indizes und Foreign Keys deterministisch sortieren

### DIFF
--- a/lib/command/diff.php
+++ b/lib/command/diff.php
@@ -128,6 +128,19 @@ final class rex_ydeploy_command_diff extends rex_ydeploy_command_abstract
                     'onDelete' => $foreignKey->getOnDelete(),
                 ];
             }
+
+            // Indexes and foreign keys are read from INFORMATION_SCHEMA without an
+            // ORDER BY, so their order is not guaranteed to be stable between runs.
+            // Sorting them by name keeps schema.yml free of spurious diffs. Columns
+            // are deliberately left untouched: their order is significant, it drives
+            // the `after` argument of ensureColumn() in generateDiff().
+            if (isset($schema[$tableName]['indexes'])) {
+                ksort($schema[$tableName]['indexes']);
+            }
+
+            if (isset($schema[$tableName]['foreignKeys'])) {
+                ksort($schema[$tableName]['foreignKeys']);
+            }
         }
 
         $schema = ['tables' => $schema];


### PR DESCRIPTION
Indizes und Foreign Keys werden ueber INFORMATION_SCHEMA ohne ORDER BY gelesen. Die Reihenfolge ist damit nicht stabil, und schema.yml aendert sich bei ydeploy:diff sporadisch, ohne dass sich strukturell etwas geaendert hat. Betroffen sind vor allem Tabellen mit mehreren Indizes oder Foreign Keys - z.B. rex_user_session, das seit dem Passkey-Feature zwei Foreign Keys hat und dessen beide Eintraege regelmaessig die Plaetze tauschen.

Das erzeugt keine Migration, aber Rauschen in der Git-History: ueber mehrere Projekte hinweg macht das jeweils ein gutes Dutzend Commits, die ausschliesslich zwei Zeilen vertauschen.

Beide Maps werden deshalb vor dem Schreiben nach Namen sortiert. Der Vergleich in generateDiff() greift ohnehin per Schluessel zu (isset($tableSchema['foreignKeys'][$name])), die Reihenfolge ist dort also bedeutungslos - es koennen dadurch weder Migrationen entstehen noch ausbleiben.

Die Spalten bleiben bewusst unsortiert: dort ist die Reihenfolge bedeutungstragend, sie speist das after-Argument von ensureColumn().

Beim ersten Lauf nach dem Update normalisiert sich schema.yml einmalig, danach bleibt die Datei stabil.